### PR TITLE
System.Text.Json and Newtonsoft.Json accept user-provided JsonSerializerOptions

### DIFF
--- a/src/JsonConverter.Newtonsoft.Json/NewtonsoftJsonConverter.cs
+++ b/src/JsonConverter.Newtonsoft.Json/NewtonsoftJsonConverter.cs
@@ -10,6 +10,21 @@ namespace JsonConverter.Newtonsoft.Json;
 
 public partial class NewtonsoftJsonConverter : IJsonConverter
 {
+    private readonly JsonSerializerSettings? _jsonSerializerSettings;
+
+    public NewtonsoftJsonConverter() : this(jsonSerializerSettings: null)
+    {
+    }
+
+    /// <summary>
+    /// Ctor with user provided <see cref="JsonSerializerSettings"/>
+    /// </summary>
+    /// <param name="jsonSerializerSettings">If not <c>null</c> then <see cref="JsonConverterOptions"/> will be applied</param>
+    public NewtonsoftJsonConverter(JsonSerializerSettings? jsonSerializerSettings)
+    {
+        _jsonSerializerSettings = jsonSerializerSettings;
+    }
+
     public T? Deserialize<T>(Stream stream, JsonConverterOptions? options = null)
     {
         Guard.NotNull(stream);
@@ -162,20 +177,23 @@ public partial class NewtonsoftJsonConverter : IJsonConverter
         };
     }
 
-    private static JsonSerializerSettings ConvertOptions(JsonConverterOptions options)
+    private JsonSerializerSettings ConvertOptions(JsonConverterOptions? options)
     {
-        var dateParseHandling = options.DateParseHandling switch
+        var result = _jsonSerializerSettings ?? new JsonSerializerSettings();
+
+        result.Formatting = options?.WriteIndented == true
+            ? Formatting.Indented
+            : Formatting.None;
+        result.NullValueHandling = options?.IgnoreNullValues == true
+            ? NullValueHandling.Ignore
+            : NullValueHandling.Include;
+        result.DateParseHandling = options?.DateParseHandling switch
         {
             0 => DateParseHandling.None,
             2 => DateParseHandling.DateTimeOffset,
             _ => DateParseHandling.DateTime
         };
 
-        return new JsonSerializerSettings
-        {
-            Formatting = options.WriteIndented ? Formatting.Indented : Formatting.None,
-            NullValueHandling = options.IgnoreNullValues ? NullValueHandling.Ignore : NullValueHandling.Include,
-            DateParseHandling = dateParseHandling
-        };
+        return result;
     }
 }

--- a/src/JsonConverter.Newtonsoft.Json/NewtonsoftJsonConverter.cs
+++ b/src/JsonConverter.Newtonsoft.Json/NewtonsoftJsonConverter.cs
@@ -163,21 +163,20 @@ public partial class NewtonsoftJsonConverter : IJsonConverter
 
     private JsonSerializerSettings ConvertOptions(JsonConverterOptions? options)
     {
-        var result = new JsonSerializerSettings(_jsonSerializerSettings ?? DefaultSettings);
-
-        result.Formatting = options?.WriteIndented == true
-            ? Formatting.Indented
-            : Formatting.None;
-        result.NullValueHandling = options?.IgnoreNullValues == true
-            ? NullValueHandling.Ignore
-            : NullValueHandling.Include;
-        result.DateParseHandling = options?.DateParseHandling switch
+        return new JsonSerializerSettings(_jsonSerializerSettings ?? DefaultSettings)
         {
-            0 => DateParseHandling.None,
-            2 => DateParseHandling.DateTimeOffset,
-            _ => DateParseHandling.DateTime
+            Formatting = options?.WriteIndented == true
+                ? Formatting.Indented
+                : Formatting.None,
+            NullValueHandling = options?.IgnoreNullValues == true
+                ? NullValueHandling.Ignore
+                : NullValueHandling.Include,
+            DateParseHandling = options?.DateParseHandling switch
+            {
+                0 => DateParseHandling.None,
+                2 => DateParseHandling.DateTimeOffset,
+                _ => DateParseHandling.DateTime
+            }
         };
-
-        return result;
     }
 }

--- a/src/JsonConverter.Newtonsoft.Json/NewtonsoftJsonConverter.cs
+++ b/src/JsonConverter.Newtonsoft.Json/NewtonsoftJsonConverter.cs
@@ -10,6 +10,8 @@ namespace JsonConverter.Newtonsoft.Json;
 
 public partial class NewtonsoftJsonConverter : IJsonConverter
 {
+    private static readonly JsonSerializerSettings DefaultSettings = new JsonSerializerSettings();
+
     private readonly JsonSerializerSettings? _jsonSerializerSettings;
 
     public NewtonsoftJsonConverter() : this(jsonSerializerSettings: null)
@@ -162,7 +164,7 @@ public partial class NewtonsoftJsonConverter : IJsonConverter
 
     private JsonSerializerSettings ConvertOptions(JsonConverterOptions? options)
     {
-        var result = _jsonSerializerSettings ?? new JsonSerializerSettings();
+        var result = new JsonSerializerSettings(_jsonSerializerSettings ?? DefaultSettings);
 
         result.Formatting = options?.WriteIndented == true
             ? Formatting.Indented

--- a/src/JsonConverter.Newtonsoft.Json/NewtonsoftJsonConverter.cs
+++ b/src/JsonConverter.Newtonsoft.Json/NewtonsoftJsonConverter.cs
@@ -32,39 +32,24 @@ public partial class NewtonsoftJsonConverter : IJsonConverter
 
         using var streamReader = new StreamReader(stream);
         using var jsonTextReader = new JsonTextReader(streamReader);
-        var jsonSerializer = new JsonSerializer();
-
-        if (options != null)
-        {
-            var serializerSettings = ConvertOptions(options);
-            jsonSerializer.Formatting = serializerSettings.Formatting;
-            jsonSerializer.NullValueHandling = serializerSettings.NullValueHandling;
-            jsonSerializer.DateParseHandling = serializerSettings.DateParseHandling;
-            jsonTextReader.DateParseHandling = serializerSettings.DateParseHandling;
-        }
+        var jsonSerializer = JsonSerializer.Create(ConvertOptions(options));
 
         return jsonSerializer.Deserialize<T>(jsonTextReader);
     }
 
     public T? Deserialize<T>(string text, JsonConverterOptions? options = null)
     {
-        return options == null
-            ? JsonConvert.DeserializeObject<T>(text)
-            : JsonConvert.DeserializeObject<T>(text, ConvertOptions(options));
+        return JsonConvert.DeserializeObject<T>(text, ConvertOptions(options));
     }
 
     public object? Deserialize(string text, Type type, JsonConverterOptions? options = null)
     {
-        return options == null
-            ? JsonConvert.DeserializeObject(text, type)
-            : JsonConvert.DeserializeObject(text, type, ConvertOptions(options));
+        return JsonConvert.DeserializeObject(text, type, ConvertOptions(options));
     }
 
     public string Serialize(object value, JsonConverterOptions? options = null)
     {
-        return options != null ?
-            JsonConvert.SerializeObject(value, ConvertOptions(options)) :
-            JsonConvert.SerializeObject(value);
+        return JsonConvert.SerializeObject(value, ConvertOptions(options));
     }
 
     public JsonType GetJsonType(Stream stream)
@@ -139,9 +124,7 @@ public partial class NewtonsoftJsonConverter : IJsonConverter
     {
         Guard.NotNullOrEmpty(text);
 
-        var result = options?.JsonConverterOptions == null ? 
-            JsonConvert.DeserializeObject(text) : 
-            JsonConvert.DeserializeObject(text, ConvertOptions(options.JsonConverterOptions));
+        var result = JsonConvert.DeserializeObject(text, ConvertOptions(options?.JsonConverterOptions));
 
         return result != null ? ConvertToDynamicJsonClass(result) : null;
     }

--- a/src/JsonConverter.Newtonsoft.Json/NewtonsoftJsonConverter.cs
+++ b/src/JsonConverter.Newtonsoft.Json/NewtonsoftJsonConverter.cs
@@ -14,15 +14,14 @@ public partial class NewtonsoftJsonConverter : IJsonConverter
 
     private readonly JsonSerializerSettings? _jsonSerializerSettings;
 
-    public NewtonsoftJsonConverter() : this(jsonSerializerSettings: null)
+    public NewtonsoftJsonConverter()
     {
     }
 
     /// <summary>
     /// Ctor with user provided <see cref="JsonSerializerSettings"/>
     /// </summary>
-    /// <param name="jsonSerializerSettings">If not <c>null</c> then <see cref="JsonConverterOptions"/> will be applied</param>
-    public NewtonsoftJsonConverter(JsonSerializerSettings? jsonSerializerSettings)
+    public NewtonsoftJsonConverter(JsonSerializerSettings jsonSerializerSettings)
     {
         _jsonSerializerSettings = jsonSerializerSettings;
     }

--- a/src/JsonConverter.System.Text.Json/SystemTextJsonConverter.cs
+++ b/src/JsonConverter.System.Text.Json/SystemTextJsonConverter.cs
@@ -174,6 +174,10 @@ public class SystemTextJsonConverter : IJsonConverter
 
     private JsonSerializerOptions ConvertOptions(JsonConverterOptions? options)
     {
+        // Note: DateParseHandling is currently ignored by JsonConverterOptions in this System.Text.Json implementation.
+        // To have custom date parsing behavior configured use user-provided JsonSerializerOptions
+        // More on that in https://learn.microsoft.com/en-us/dotnet/standard/datetime/system-text-json-support
+
         return new JsonSerializerOptions(_jsonSerializerOptions ?? DefaultOptions)
         {
             PropertyNameCaseInsensitive = options?.PropertyNameCaseInsensitive ?? false,

--- a/src/JsonConverter.System.Text.Json/SystemTextJsonConverter.cs
+++ b/src/JsonConverter.System.Text.Json/SystemTextJsonConverter.cs
@@ -174,16 +174,15 @@ public class SystemTextJsonConverter : IJsonConverter
 #else
         var defaultJsonSerializerOptions = new JsonSerializerOptions();
 #endif
-        var result = new JsonSerializerOptions(_jsonSerializerOptions ?? defaultJsonSerializerOptions);
 
-        if (options != null)
+        var result = new JsonSerializerOptions(_jsonSerializerOptions ?? defaultJsonSerializerOptions)
         {
-            result.PropertyNameCaseInsensitive = options.PropertyNameCaseInsensitive;
-            result.WriteIndented = options.WriteIndented;
-            result.DefaultIgnoreCondition = options.IgnoreNullValues
+            PropertyNameCaseInsensitive = options?.PropertyNameCaseInsensitive ?? false,
+            WriteIndented = options?.WriteIndented ?? false,
+            DefaultIgnoreCondition = options?.IgnoreNullValues == true
                 ? JsonIgnoreCondition.WhenWritingNull
-                : JsonIgnoreCondition.Never;
-        }
+                : JsonIgnoreCondition.Never
+        };
 
         return result;
     }

--- a/src/JsonConverter.System.Text.Json/SystemTextJsonConverter.cs
+++ b/src/JsonConverter.System.Text.Json/SystemTextJsonConverter.cs
@@ -29,7 +29,7 @@ public class SystemTextJsonConverter : IJsonConverter
         Guard.Condition(stream, s => s.CanSeek);
 
         stream.Seek(0L, SeekOrigin.Begin);
-        return JsonSerializer.Deserialize<T>(stream, options == null ? null : ConvertOptions(options));
+        return JsonSerializer.Deserialize<T>(stream, ConvertOptions(options));
     }
 
     public async Task<T?> DeserializeAsync<T>(Stream stream, JsonConverterOptions? options = null, CancellationToken cancellationToken = default)
@@ -38,7 +38,7 @@ public class SystemTextJsonConverter : IJsonConverter
         Guard.Condition(stream, s => s.CanSeek);
 
         stream.Seek(0L, SeekOrigin.Begin);
-        return await JsonSerializer.DeserializeAsync<T>(stream, options == null ? null : ConvertOptions(options), cancellationToken).ConfigureAwait(false);
+        return await JsonSerializer.DeserializeAsync<T>(stream, ConvertOptions(options), cancellationToken).ConfigureAwait(false);
     }
 
     public T? Deserialize<T>(string text, JsonConverterOptions? options = null)
@@ -118,13 +118,13 @@ public class SystemTextJsonConverter : IJsonConverter
     {
         Guard.NotNull(stream);
 
-        return JsonSerializer.SerializeAsync(stream, value, options == null ? null : ConvertOptions(options), cancellationToken);
+        return JsonSerializer.SerializeAsync(stream, value, ConvertOptions(options), cancellationToken);
     }
 
     public async Task<string> SerializeAsync(object value, JsonConverterOptions? options = null, CancellationToken cancellationToken = default)
     {
         using var stream = new MemoryStream();
-        await JsonSerializer.SerializeAsync(stream, value, options == null ? null : ConvertOptions(options), cancellationToken);
+        await JsonSerializer.SerializeAsync(stream, value, ConvertOptions(options), cancellationToken);
         stream.Position = 0L;
 
         using var reader = new StreamReader(stream);

--- a/src/JsonConverter.System.Text.Json/SystemTextJsonConverter.cs
+++ b/src/JsonConverter.System.Text.Json/SystemTextJsonConverter.cs
@@ -174,7 +174,7 @@ public class SystemTextJsonConverter : IJsonConverter
 
     private JsonSerializerOptions ConvertOptions(JsonConverterOptions? options)
     {
-        var result = new JsonSerializerOptions(_jsonSerializerOptions ?? DefaultOptions)
+        return new JsonSerializerOptions(_jsonSerializerOptions ?? DefaultOptions)
         {
             PropertyNameCaseInsensitive = options?.PropertyNameCaseInsensitive ?? false,
             WriteIndented = options?.WriteIndented ?? false,
@@ -182,7 +182,5 @@ public class SystemTextJsonConverter : IJsonConverter
                 ? JsonIgnoreCondition.WhenWritingNull
                 : JsonIgnoreCondition.Never
         };
-
-        return result;
     }
 }

--- a/src/JsonConverter.System.Text.Json/SystemTextJsonConverter.cs
+++ b/src/JsonConverter.System.Text.Json/SystemTextJsonConverter.cs
@@ -16,15 +16,14 @@ public class SystemTextJsonConverter : IJsonConverter
 
     private readonly JsonSerializerOptions? _jsonSerializerOptions;
 
-    public SystemTextJsonConverter() : this(jsonSerializerOptions: null)
+    public SystemTextJsonConverter()
     {
     }
 
     /// <summary>
     /// Ctor with user provided <see cref="JsonSerializerOptions"/>
     /// </summary>
-    /// <param name="jsonSerializerOptions">If not <c>null</c> then <see cref="JsonConverterOptions"/> will be applied</param>
-    public SystemTextJsonConverter(JsonSerializerOptions? jsonSerializerOptions)
+    public SystemTextJsonConverter(JsonSerializerOptions jsonSerializerOptions)
     {
         _jsonSerializerOptions = jsonSerializerOptions;
     }

--- a/src/JsonConverter.System.Text.Json/SystemTextJsonConverter.cs
+++ b/src/JsonConverter.System.Text.Json/SystemTextJsonConverter.cs
@@ -8,6 +8,12 @@ namespace JsonConverter.System.Text.Json;
 
 public class SystemTextJsonConverter : IJsonConverter
 {
+#if NET8_0_OR_GREATER
+    private static readonly JsonSerializerOptions DefaultOptions = JsonSerializerOptions.Default;
+#else
+    private static readonly JsonSerializerOptions DefaultOptions = new JsonSerializerOptions();
+#endif
+
     private readonly JsonSerializerOptions? _jsonSerializerOptions;
 
     public SystemTextJsonConverter() : this(jsonSerializerOptions: null)
@@ -169,13 +175,7 @@ public class SystemTextJsonConverter : IJsonConverter
 
     private JsonSerializerOptions ConvertOptions(JsonConverterOptions? options)
     {
-#if NET8_0_OR_GREATER
-        var defaultJsonSerializerOptions = JsonSerializerOptions.Default;
-#else
-        var defaultJsonSerializerOptions = new JsonSerializerOptions();
-#endif
-
-        var result = new JsonSerializerOptions(_jsonSerializerOptions ?? defaultJsonSerializerOptions)
+        var result = new JsonSerializerOptions(_jsonSerializerOptions ?? DefaultOptions)
         {
             PropertyNameCaseInsensitive = options?.PropertyNameCaseInsensitive ?? false,
             WriteIndented = options?.WriteIndented ?? false,

--- a/src/JsonConverter.System.Text.Json/SystemTextJsonConverter.cs
+++ b/src/JsonConverter.System.Text.Json/SystemTextJsonConverter.cs
@@ -8,6 +8,21 @@ namespace JsonConverter.System.Text.Json;
 
 public class SystemTextJsonConverter : IJsonConverter
 {
+    private readonly JsonSerializerOptions? _jsonSerializerOptions;
+
+    public SystemTextJsonConverter() : this(jsonSerializerOptions: null)
+    {
+    }
+
+    /// <summary>
+    /// Ctor with user provided <see cref="JsonSerializerOptions"/>
+    /// </summary>
+    /// <param name="jsonSerializerOptions">If not <c>null</c> then <see cref="JsonConverterOptions"/> will be ignored</param>
+    public SystemTextJsonConverter(JsonSerializerOptions? jsonSerializerOptions)
+    {
+        _jsonSerializerOptions = jsonSerializerOptions;
+    }
+
     public T? Deserialize<T>(Stream stream, JsonConverterOptions? options = null)
     {
         Guard.NotNull(stream);
@@ -152,8 +167,13 @@ public class SystemTextJsonConverter : IJsonConverter
         };
     }
 
-    private static JsonSerializerOptions? ConvertOptions(JsonConverterOptions? options)
+    private JsonSerializerOptions? ConvertOptions(JsonConverterOptions? options)
     {
+        if (_jsonSerializerOptions != null)
+        {
+            return _jsonSerializerOptions;
+        }
+
         if (options == null)
         {
             return null;

--- a/src/JsonConverter.System.Text.Json/SystemTextJsonConverter.cs
+++ b/src/JsonConverter.System.Text.Json/SystemTextJsonConverter.cs
@@ -167,29 +167,24 @@ public class SystemTextJsonConverter : IJsonConverter
         };
     }
 
-    private JsonSerializerOptions? ConvertOptions(JsonConverterOptions? options)
+    private JsonSerializerOptions ConvertOptions(JsonConverterOptions? options)
     {
-        if (_jsonSerializerOptions != null)
+#if NET8_0_OR_GREATER
+        var defaultJsonSerializerOptions = JsonSerializerOptions.Default;
+#else
+        var defaultJsonSerializerOptions = new JsonSerializerOptions();
+#endif
+        var result = new JsonSerializerOptions(_jsonSerializerOptions ?? defaultJsonSerializerOptions);
+
+        if (options != null)
         {
-            return _jsonSerializerOptions;
+            result.PropertyNameCaseInsensitive = options.PropertyNameCaseInsensitive;
+            result.WriteIndented = options.WriteIndented;
+            result.DefaultIgnoreCondition = options.IgnoreNullValues
+                ? JsonIgnoreCondition.WhenWritingNull
+                : JsonIgnoreCondition.Never;
         }
 
-        if (options == null)
-        {
-            return null;
-        }
-
-        var jsonOptions = new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = options.PropertyNameCaseInsensitive,
-            WriteIndented = options.WriteIndented,
-            DefaultIgnoreCondition = options.IgnoreNullValues ? JsonIgnoreCondition.WhenWritingNull : JsonIgnoreCondition.Never
-        };
-
-        // Note: DateParseHandling is currently ignored by this System.Text.Json implementation.
-        // No custom date parsing behavior is configured here; string properties remain strings by default.
-        // DateParseHandling is mainly supported by the Newtonsoft.Json implementation.
-
-        return jsonOptions;
+        return result;
     }
 }

--- a/src/JsonConverter.System.Text.Json/SystemTextJsonConverter.cs
+++ b/src/JsonConverter.System.Text.Json/SystemTextJsonConverter.cs
@@ -17,7 +17,7 @@ public class SystemTextJsonConverter : IJsonConverter
     /// <summary>
     /// Ctor with user provided <see cref="JsonSerializerOptions"/>
     /// </summary>
-    /// <param name="jsonSerializerOptions">If not <c>null</c> then <see cref="JsonConverterOptions"/> will be ignored</param>
+    /// <param name="jsonSerializerOptions">If not <c>null</c> then <see cref="JsonConverterOptions"/> will be applied</param>
     public SystemTextJsonConverter(JsonSerializerOptions? jsonSerializerOptions)
     {
         _jsonSerializerOptions = jsonSerializerOptions;

--- a/tests/JsonConverter.System.Text.Json.Tests/UnitTest1.cs
+++ b/tests/JsonConverter.System.Text.Json.Tests/UnitTest1.cs
@@ -195,10 +195,44 @@ public class UnitTest1
         result.Value.Should().Be(99);
     }
 
+    [Fact]
+    public void Serialize_UserProvidedSettings_Success()
+    {
+        // Arrange
+        var jsonSerializerOptions = new JsonSerializerOptions
+        {
+            Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+        };
+        var sut = new SystemTextJsonConverter(jsonSerializerOptions);
+
+        var classWithEnum = new ClassWithEnum
+        {
+            Type = (ClassWithEnumType)Random.Shared.Next(3)
+        };
+
+        // Act
+        var result = sut.Serialize(classWithEnum, options: null);
+
+        // Assert
+        result.Should().Contain(classWithEnum.Type.ToString().ToLower());
+    }
+
     private sealed class TestModel
     {
         public string Name { get; set; } = string.Empty;
 
         public int Value { get; set; }
+    }
+
+    private sealed class ClassWithEnum
+    {
+        public ClassWithEnumType Type { get; set; }
+    }
+
+    private enum ClassWithEnumType
+    {
+        Default = 0,
+        First = 1,
+        Second = 2
     }
 }


### PR DESCRIPTION
# Description
While using WireMock with STJ i lose the ability to apply the converters and other settings to server serialization process. This PR solves the problem adding public ctor allowing to set specific `JsonSerializerOptions` which will override `JsonConverterOptions` conversion result:
- `SystemTextJsonConverter` with user provided options
- refactoring of `ConvertOptions` usage as it already considers nullability
- tests

# Use Case
```cs
WireMockServer = WireMockServer.Start(
    new WireMockServerSettings
    {
        DefaultJsonSerializer = new SystemTextJsonConverter(
            new JsonSerializerOptions
            {
                // ...
            }),
    });
```